### PR TITLE
Link against static MSVC runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           CL: /MP # Build with multiple processes
         run: |
           $configArgs = Get-Content ..\feature-flags.txt | Where-Object { $_.Trim() -ne '' }
-          ..\qt\configure.bat @configArgs -- -DCMAKE_CXX_FLAGS="/await:strict"
+          ..\qt\configure.bat @configArgs -- -DCMAKE_CXX_FLAGS="/await:strict" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
           cmake --build . --parallel 4
 
       - name: Build Qt (macOS)


### PR DESCRIPTION
Hi,
you are building static versions of Qt 6 libraries, but those libraries themselves require `MSVCP140.dll` and the likes, because [by default CMake links against dynamic MSVC runtime](https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html). This PR adds the required setting to make the Qt 6 libraries fully static.

This was tested on Windows 2022.